### PR TITLE
chore(examples): fix pom of heater example

### DIFF
--- a/kura/examples/bnd_examples/org.eclipse.kura.demo.bnd.heater/pom.xml
+++ b/kura/examples/bnd_examples/org.eclipse.kura.demo.bnd.heater/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
@@ -12,7 +13,6 @@
       Eurotech
 
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
The current pom is broker. I get the following:

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-parseable POM ...\pom.xml: processing instruction can not have PITarget with reserved xml name (position: START_DOCUMENT seen ...-I @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project  (....\pom.xml) has 1 error
[ERROR]     Non-parseable POM ....\pom.xml: processing instruction can not have PITarget with reserved xml name (position: START_DOCUMENT seen ...-Identifier: EPL-2.0\n\n    Contributors:\n      Eurotech\n\n-->\n<?xml ... @15:7)  @ line 15, column 7 -> [Help 2]
[ERROR]

```

**Description of the solution adopted:** 

The solution is to move the <?xml bla bla> to the top of the file. I think this is on all other poms already.

**Manual Tests**: 

After the change, I get BUILD SUCCESS.

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
